### PR TITLE
Cross-platform alert_handler.py

### DIFF
--- a/bin/alert_handler.py
+++ b/bin/alert_handler.py
@@ -19,9 +19,10 @@ import datetime
 import hashlib
 import re
 import uuid
+import tempfile
 
-sys.stdout = open('/tmp/stdout', 'a')
-sys.stderr = open('/tmp/stderr', 'a')
+sys.stdout = open(os.path.join(tempfile.gettempdir(), 'stdout'), 'a')
+sys.stderr = open(os.path.join(tempfile.gettempdir(), 'stderr'), 'a')
 
 dir = os.path.join(os.path.join(os.environ.get('SPLUNK_HOME')), 'etc', 'apps', 'alert_manager', 'bin', 'lib')
 if not dir in sys.path:


### PR DESCRIPTION
- Had to change the file in order to run on the Windows platform without errors (script failed to create the files '/tmp/stdout' and '/tmp/stderr')
- tempfile module allows to provide a cross-platform method to work with temp directories and files
- tempfile is available by default