### PR TITLE
Fixed alert.priority not looking up using search result and template path swapped issue

### DIFF
--- a/src/bin/alert_manager.py
+++ b/src/bin/alert_manager.py
@@ -472,6 +472,8 @@ def getAppSettings(sessionKey):
 
 def getIncidentSettings(payload, app_settings, search_name, sessionKey):
     cfg = payload.get('configuration')
+    result = payload.get('result')
+    
     settings = {}
     settings['title']                    = search_name if ('title' not in cfg or cfg['title'] == '') else cfg['title']
     settings['auto_assign_owner']        = 'unassigned' if ('auto_assign_owner' not in cfg or cfg['auto_assign_owner'] == '') else cfg['auto_assign_owner']
@@ -479,8 +481,20 @@ def getIncidentSettings(payload, app_settings, search_name, sessionKey):
     settings['auto_ttl_resolve']         = False if ('auto_ttl_resolve' not in cfg or cfg['auto_ttl_resolve'] == '') else normalize_bool(cfg['auto_ttl_resolve'])
     settings['auto_previous_resolve']    = False if ('auto_previous_resolve' not in cfg or cfg['auto_previous_resolve'] == '') else normalize_bool(cfg['auto_previous_resolve'])
     settings['auto_subsequent_resolve']  = False if ('auto_subsequent_resolve' not in cfg or cfg['auto_subsequent_resolve'] == '') else normalize_bool(cfg['auto_subsequent_resolve'])
-    settings['impact']                   = '' if ('impact' not in cfg or cfg['impact'] == '') else cfg['impact']
-    settings['urgency']                  = '' if ('urgency' not in cfg or cfg['urgency'] == '') else cfg['urgency']
+    
+    if ('impact' in result or result['impact'] != ''):
+        settings['impact'] = result['impact']
+    elif ('impact' not in cfg or cfg['impact'] == ''):
+        settings['impact'] = ''
+    else:
+        settings['impact'] = cfg['impact']
+
+    if ('urgency' in result or result['urgency'] != ''):
+        settings['urgency'] = result['urgency']
+    elif ('urgency' not in cfg or cfg['urgency'] == ''):
+        settings['urgency'] = ''
+    else:
+        settings['urgency'] = cfg['urgency']
 
     # Fetch additional settings from incident_settings collection
     query = '{{ "alert": "{}" }}'.format(search_name)

--- a/src/bin/lib/NotificationHandler.py
+++ b/src/bin/lib/NotificationHandler.py
@@ -67,8 +67,8 @@ class NotificationHandler(object):
         self.sessionKey = sessionKey
 
         # Setup template paths
-        local_dir = os.path.join(util.get_apps_dir(), "alert_manager", "default", "templates")
-        default_dir = os.path.join(util.get_apps_dir(), "alert_manager", "local", "templates")
+        local_dir = os.path.join(util.get_apps_dir(), "alert_manager", "local", "templates")
+        default_dir = os.path.join(util.get_apps_dir(), "alert_manager", "default", "templates")
         loader = FileSystemLoader([default_dir, local_dir])
         self.env = Environment(loader=loader, variable_start_string='$', variable_end_string='$')
 


### PR DESCRIPTION
As stated in 'Add action':
"Default impact for incidents of this alert.
Note: The impact can be overriden by a field from search results named 'impact'. Later, the alert manager calculates a priority based on the impact and urgency."

That is not the case. Orginally, the result.impact and result.urgency is not used to lookup alert.priority, thus, causing other errors. For example, $alert.priority$ in email is using the the payload.configuration.impact & payload.configuration.urgency for lookup.