### PR TITLE
Align time to show trends more clearly

### DIFF
--- a/src/default/data/ui/views/incident_posture.xml
+++ b/src/default/data/ui/views/incident_posture.xml
@@ -11,7 +11,7 @@
     </input>
   </fieldset>
   <search id="base_single_search">
-    <query>`all_alerts_single_trend` | append [makeresults] | timechart span=1d count by priority | fillnull value=0 informational, low, medium, high, critical</query>
+    <query>`all_alerts_single_trend` | append [makeresults] | timechart span=1440m aligntime="+1m@m" count by priority | fillnull value=0 informational, low, medium, high, critical</query>
     <earliest>$global_time.earliest$</earliest>
     <latest>$global_time.latest$</latest>
   </search>


### PR DESCRIPTION
Default timechart behaviour aligns a 1d span time to midnight. This causes trend lines to only represent a part of a day, and consequently almost always appear as a downward trend regardless of what is actually occurring. Using aligntime and defining span in minutes instead of days allows it to display as a representation of the last rolling 24h compared to the 24h span preceding that.

Example:
2021-06-09 01:00 "Alert"
2021-06-09 04:00 "Alert"
2021-06-09 17:00 "Alert"
2021-06-09 23:00 "Alert"
2021-06-10 01:00 "Alert"
2021-06-10 04:00 "Alert"
2021-06-10 17:00 "Alert"
2021-06-10 23:00 "Alert"
2021-06-11 01:00 "Alert"

Running `timechart span=1d count` at 2021-06-11 02:00 gives:
2021-06-10 count=4
2021-06-11 count=1
trend -3

Whereas `timechart span=1440m aligntime="+1m@m"` at the same time gives:
2021-06-10 02:01 count=4
2021-06-11 02:01 count=4
trend 0